### PR TITLE
Update deps to fix with newer clang

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jpegxr"
-version = "0.3.0"
-authors = ["Brion Vibber <brion@pobox.com>"]
+version = "0.3.1"
+authors = ["Brooke Vibber <bvibber@pobox.com>"]
 edition = "2018"
 license = "BSD-3-Clause"
 description = "Wrapper for Microsoft's C JPEG XR image codec library"
@@ -14,9 +14,9 @@ categories = ["multimedia::images"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thiserror = "1.0.29"
-libc = "0.2.102"
+thiserror = "1.0.57"
+libc = "0.2.153"
 
 [build-dependencies]
-cc = { version = "1.0.67", features = ["parallel"] }
-bindgen = "0.68.1"
+cc = { version = "1.0.83", features = ["parallel"] }
+bindgen = "0.69.4"

--- a/build.rs
+++ b/build.rs
@@ -116,7 +116,7 @@ fn main() {
         .clang_args(clang_args)
         .derive_eq(true)
         .size_t_is_usize(true)
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .generate()
         .expect("Error building libjpegxr bindings")
         .write_to_file(out_path.join("bindings.rs"))

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jpegxr",
     "jxr"
   ],
-  "author": "Brion Vibber <brion@pobox.com>",
+  "author": "Brooke Vibber <bvibber@pobox.com>",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/brion/jpegxr/issues"

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Currently only decoding is supported, but adding an encoder interface should be 
 # Authors
 
 The wrapped C JPEG XR library was written by many fine folks at Microsoft!
-Rust and JS code wrapping it, and tweaks to the C code, are by Brion Vibber `<brion @ pobox.com>`.
+Rust and JS code wrapping it, and tweaks to the C code, are by Brooke Vibber `<bvibber@pobox.com>`.
 
 # License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //
-// Copyright © Brion Vibber
+// Copyright © Brooke Vibber
 // Some rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -26,6 +26,7 @@
 
 // turn on all clippy's lints by default
 #![warn(clippy::all)]
+#![allow(unused_imports)]
 // this quiets the compiler about the C constant names
 #![allow(non_upper_case_globals)]
 // this is triggered by test cases in bindgen code


### PR DESCRIPTION
Update deps, names
Version number bump to 0.3.1

---

This is a cherry-pick of https://github.com/brion/jpegxr/commit/3e8b298304cd8a42e773afb0af5cf57bd49549c4.