### PR TITLE
chore: Fix compile error when using MinGW gcc

### DIFF
--- a/jxrlib/jxrgluelib/JXRMeta.h
+++ b/jxrlib/jxrgluelib/JXRMeta.h
@@ -36,6 +36,16 @@
 #define UNREFERENCED_PARAMETER(P) { (P) = (P); }
 #endif
 
+#ifndef __in_ecount
+#include <specstrings.h>
+#ifdef SAL__in_ecount
+#define __in_ecount(size) SAL__in_ecount(size)
+#endif
+#ifdef SAL__out_ecount
+#define __out_ecount(size) SAL__out_ecount(size)
+#endif
+#endif
+
 //================================================================
 // Container
 //================================================================


### PR DESCRIPTION
See: https://sourceforge.net/p/mingw/bugs/2041/
<pre><code>...
  cargo:warning=In file included from jxrlib/jxrgluelib/JXRGlue.h:34,
  cargo:warning=                 from jxrlib/jxrgluelib/JXRGlue.c:32:
  cargo:warning=jxrlib/jxrgluelib/JXRMeta.h:40:27: error: unknown type name 'SAL__in_ecount'
  cargo:warning=   40 | #define __in_ecount(size) SAL__in_ecount(size)
  cargo:warning=      |                           ^~~~~~~~~~~~~~
  cargo:warning=jxrlib/jxrgluelib/JXRMeta.h:202:5: note: in expansion of macro '__in_ecount'
  cargo:warning=  202 |     __in_ecount(1) struct WMPStream* pWS,
  cargo:warning=      |     ^~~~~~~~~~~
  cargo:warning=jxrlib/jxrgluelib/JXRMeta.h:204:5: error: unknown type name '__out_ecount'
  cargo:warning=  204 |     __out_ecount(1) U16* puValue
  cargo:warning=      |     ^~~~~~~~~~~~
...</code></pre>
